### PR TITLE
[Common] Makefile Helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+PREFIX = riscv64-unknown-elf-
+
+CC = $(PREFIX)gcc
+CXX = $(PREFIX)g++
+CP = $(PREFIX)objcopy
+OD = $(PREFIX)objdump
+DG = $(PREFIX)gdb
+SIZE = $(PREFIX)size
+
 .PHONY: build
 dsp24:
 	cmake -S ./ -B ./build/ -D CMAKE_TOOLCHAIN_FILE=./riscv-gcc.cmake -DCHIP=dsp24
@@ -7,10 +16,27 @@ bearly24:
 	cmake -S ./ -B ./build/ -D CMAKE_TOOLCHAIN_FILE=./riscv-gcc.cmake -DCHIP=bearly24
 	cmake --build ./build/ --target app
 
+# Example: make build TARGET=borai CHIP=bearly24
+.PHONY: build
+build:
+	cmake -S ./ -B ./build/ -D CMAKE_TOOLCHAIN_FILE=./riscv-gcc.cmake -DCHIP=$(CHIP)
+        cmake --build ./build/ --target $(TARGET)
+
+# Example: make ocd CHIP=bearly24
+.PHONY: ocd
+ocd:
+        openocd -f ./platform/$(CHIP)/$(CHIP).cfg
+
+# Example: make gdb BINARY=build/borai/boraiq.elf
+.PHONY: gdb
+gdb:
+        $(DG) $(BINARY) --eval-command="target extended-remote localhost:3333" --eval-command="monitor reset"
+
+# Example: make dump BINARY=build/borai/boraiq.elf
+.PHONY: dump
+dump:
+        $(OD) -D  $(BINARY) > $(BINARY).dump
+
 .PHONY: clean
 clean:
 	rm -rf build
-
-.PHONY: dump
-dump:
-	riscv64-unknown-elf-objdump -D  build/app.elf > dump.txt

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ OD = $(PREFIX)objdump
 DG = $(PREFIX)gdb
 SIZE = $(PREFIX)size
 
+# Can be used to change HART for gdb debugging
+PORT = 3333
+
 .PHONY: build
 dsp24:
 	cmake -S ./ -B ./build/ -D CMAKE_TOOLCHAIN_FILE=./riscv-gcc.cmake -DCHIP=dsp24
@@ -30,7 +33,7 @@ ocd:
 # Example: make gdb BINARY=build/borai/boraiq.elf
 .PHONY: gdb
 gdb:
-        $(DG) $(BINARY) --eval-command="target extended-remote localhost:3333" --eval-command="monitor reset"
+        $(DG) $(BINARY) --eval-command="target extended-remote localhost:$(PORT)" --eval-command="monitor reset"
 
 # Example: make dump BINARY=build/borai/boraiq.elf
 .PHONY: dump

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,11 @@ dump:
 .PHONY: clean
 clean:
 	rm -rf build
+
+.PHONY: checktsi
+checktsi:
+	uart_tsi +tty=$(TTY) +baudrate=921600 +no_hart0_msip +init_write=0x80001000:0xb0bacafe +init_read=0x80001000 none
+
+.PHONY: tsi
+tsi:
+	uart_tsi +tty=$(TTY) +baudrate=921600 $(BINARY)


### PR DESCRIPTION
Adds the following:
- Perform full build for chip and target: `make build TARGET=target_name CHIP=chip_name`
- Launch OpenOCD for a given chip: `make ocd CHIP=chip_name`
- Launch GDB for a given binary: `make gdb BINARY=build/path/to/file.elf`
- Create dump of an ELF binary: `make dump BINARY=build/path/to/file.elf`
