### PR TITLE
Draft: Initial PRCI drivers for Bearly and DSP

### DIFF
--- a/driver/intel/pll/pll.h
+++ b/driver/intel/pll/pll.h
@@ -8,10 +8,6 @@ extern "C" {
 #include "metal.h"
 
 typedef struct {
-  __IO uint32_t SEL;                                    // 0x00
-} ClockSel_Type;
-
-typedef struct {
   __IO uint32_t FZ_TIGHT_LOOPB;                         // 0x00
   __IO uint32_t FZ_LOCKFORCE;                           // 0x04
   __IO uint32_t FZ_LOCKCNT;                             // 0x08

--- a/platform/bearly24/inc/hal_rcc.h
+++ b/platform/bearly24/inc/hal_rcc.h
@@ -1,0 +1,26 @@
+/**
+ * @file hal_rcc.h
+ * @author Jasmine Angle (angle@berkeley.edu)
+ * @brief 
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+ #ifndef __HAL_RCC_H
+ #define __HAL_RCC_H
+ 
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+ 
+ #include "metal.h"
+ #include "ll_rcc.h"
+ 
+ #ifdef __cplusplus
+ }
+ #endif
+ 
+ #endif /* __HAL_RCC_H */
+ 

--- a/platform/bearly24/inc/ll_rcc.h
+++ b/platform/bearly24/inc/ll_rcc.h
@@ -1,0 +1,39 @@
+#ifndef __LL_RCC_H
+#define __LL_RCC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "metal.h"
+
+typedef struct {
+  __IO uint32_t TILE0_RESET;      /** RocketTile 0 */   // 0x00
+  __IO uint32_t TILE1_RESET;      /** RocketTile 1 */   // 0x04
+  __IO uint32_t TILE2_RESET;      /** RocketTile 2 */   // 0x08
+  __IO uint32_t TILE3_RESET;      /** RocketTile 3 */   // 0x0C
+  uint32_t RESERVED0[1020];
+  __IO uint32_t TILE0_CLKGATE;    /** RocketTile 0 */   // 0x1000
+  __IO uint32_t TILE1_CLKGATE;    /** RocketTile 1 */   // 0x1004
+  __IO uint32_t TILE2_CLKGATE;    /** RocketTile 2 */   // 0x1008
+  __IO uint32_t TILE3_CLKGATE;    /** RocketTile 3 */   // 0x100C
+  uint32_t RESERVED1[1020];
+  __IO uint32_t CLK_SEL;          /** Selects the system clock. 0: External slow clock, 1: PLL clock */
+  __IO uint32_t DEBUG_CLK_EN;                           // 0x2004
+  __IO uint32_t DEBUG_CLK_SEL;                          // 0x2008
+  __IO uint32_t DEBUG_CLK_DIV;                          // 0x200C
+  uint32_t RESERVED2[1020];
+  __IO uint32_t FBUS_CLK_DIV;                           // 0x3000
+  __IO uint32_t UNCORE_CLK_DIV;                         // 0x3004
+  __IO uint32_t TILE0_CLK_DIV;                          // 0x3008
+  __IO uint32_t TILE1_CLK_DIV;                          // 0x300C
+  __IO uint32_t TILE2_CLK_DIV;                          // 0x3010
+  __IO uint32_t TILE3_CLK_DIV;                          // 0x3014
+} RCC_Type;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LL_RCC_H */

--- a/platform/dsp24/inc/hal_rcc.h
+++ b/platform/dsp24/inc/hal_rcc.h
@@ -1,0 +1,26 @@
+/**
+ * @file hal_rcc.h
+ * @author Jasmine Angle (angle@berkeley.edu)
+ * @brief 
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+ #ifndef __HAL_RCC_H
+ #define __HAL_RCC_H
+ 
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+ 
+ #include "metal.h"
+ #include "ll_rcc.h"
+ 
+ #ifdef __cplusplus
+ }
+ #endif
+ 
+ #endif /* __HAL_RCC_H */
+ 

--- a/platform/dsp24/inc/ll_rcc.h
+++ b/platform/dsp24/inc/ll_rcc.h
@@ -1,0 +1,39 @@
+#ifndef __LL_RCC_H
+#define __LL_RCC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "metal.h"
+
+typedef struct {
+  __IO uint32_t TILE0_RESET;      /** RocketTile 0 */   // 0x00
+  __IO uint32_t TILE1_RESET;      /** RocketTile 1 */   // 0x04
+  __IO uint32_t TILE2_RESET;      /** RocketTile 2 */   // 0x08
+  __IO uint32_t TILE3_RESET;      /** RocketTile 3 */   // 0x0C
+  uint32_t RESERVED0[1020];
+  __IO uint32_t TILE0_CLKGATE;    /** RocketTile 0 */   // 0x1000
+  __IO uint32_t TILE1_CLKGATE;    /** RocketTile 1 */   // 0x1004
+  __IO uint32_t TILE2_CLKGATE;    /** RocketTile 2 */   // 0x1008
+  __IO uint32_t TILE3_CLKGATE;    /** RocketTile 3 */   // 0x100C
+  uint32_t RESERVED1[1020];
+  __IO uint32_t CLK_SEL;          /** Selects the system clock. 0: External slow clock, 1: PLL clock */
+  __IO uint32_t DEBUG_CLK_EN;                           // 0x2004
+  __IO uint32_t DEBUG_CLK_SEL;                          // 0x2008
+  __IO uint32_t DEBUG_CLK_DIV;                          // 0x200C
+  uint32_t RESERVED2[1020];
+  __IO uint32_t FBUS_CLK_DIV;                           // 0x3000
+  __IO uint32_t UNCORE_CLK_DIV;                         // 0x3004
+  __IO uint32_t TILE0_CLK_DIV;                          // 0x3008
+  __IO uint32_t TILE1_CLK_DIV;                          // 0x300C
+  __IO uint32_t TILE2_CLK_DIV;                          // 0x3010
+  __IO uint32_t TILE3_CLK_DIV;                          // 0x3014
+} RCC_Type;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LL_RCC_H */


### PR DESCRIPTION
Shifts delegation of clock selection assignment to an overall PRCI struct to account for the rest of the reset/clock division functionality.

Need to test on 2025-02-25, will update this PR once I've tested this driver.