### PR TITLE
ADD: make build compatible with riscv64-unknown-elf-gcc-14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ add_compile_options(-s)
 
 # add_compile_options(-ffunction-sections -fdata-sections -fno-common -fno-builtin-printf -fno-pie)
 # add_compile_options(-Wall -Wextra -Warray-bounds -Wno-unused-parameter -Wcast-qual)
+# make compatible with riscv64-unknown-elf-gcc (g04696df09) 14.2.0 -- ignore the previous warnings that now have become errors - https://gcc.gnu.org/gcc-14/porting_to.html
+add_compile_options(-fpermissive)
 add_compile_options(${ARCH_FLAGS})
 add_compile_options(${SPEC_FLAGS})
 

--- a/platform/dsp24/CMakeLists.txt
+++ b/platform/dsp24/CMakeLists.txt
@@ -6,6 +6,9 @@ file(GLOB_RECURSE PLATFORM_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c )
 add_library(chip-config STATIC chip.c ${PLATFORM_FILES})
 
+# make compatible with riscv64-unknown-elf-gcc (g04696df09) 14.2.0 -- ignore the previous warnings that now have become errors - https://gcc.gnu.org/gcc-14/porting_to.html
+target_compile_options(chip-config PRIVATE -fpermissive) # PRIVATE = applies to chip-config source files only
+
 # set terminal device (printf, scanf, etc.) to HTIF
 set(TERMINAL_DEVICE_UART0   ON    PARENT_SCOPE)
 target_compile_definitions(chip-config PUBLIC -D TERMINAL_DEVICE_UART0)


### PR DESCRIPTION
## Issue
[Homebrew version of riscv-tools](https://github.com/riscv-software-src/homebrew-riscv) that folks on mac install now will be on gcc-14 -- [gcc14 made many previous warnings into errors](https://gcc.gnu.org/gcc-14/porting_to.html) recently and that means anyone with new versions of the riscv toolchain that try to `make` this will have it fail.

## Fix
* ADD: compiler option (`-fpermissive`) that tells gcc to turn the errors back into warnings